### PR TITLE
Add namespace to the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your project root folder
 2. In your Pimple container configuration, register the WhoopsServiceProvider:
 
 ```php
-$container->register(new WhoopsServiceProvider);
+$container->register(new \WhoopsPimple\WhoopsServiceProvider);
 ```
 
 -----


### PR DESCRIPTION
It's nice to make sure code examples are copy and pasteable right away.
